### PR TITLE
chore: add release discovery

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   DEFAULT_NODE_VERSION: "16.15.1"
+  SENTRY_RELEASE: "default_release_name"
 
 jobs:
   build:

--- a/packages/unplugin/src/getReleaseName.ts
+++ b/packages/unplugin/src/getReleaseName.ts
@@ -1,0 +1,38 @@
+import * as child_process from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+
+function isGit(dir: string) {
+  return fs.existsSync(path.join(dir, ".git"));
+}
+
+function getBranchHead() {
+  return child_process.execSync("git rev-parse HEAD").toString().trim();
+}
+
+export function getReleaseName(releaseName?: string): string {
+  if (releaseName) {
+    return releaseName;
+  }
+
+  const ENV_VARS = [
+    "SENTRY_RELEASE",
+    "SOURCE_VERSION", // Heroku #1 https://devcenter.heroku.com/changelog-items/630
+    "HEROKU_SLUG_COMMIT", // Heroku #2: https://docs.sentry.io/product/integrations/deployment/heroku/#configure-releases
+    "CODEBUILD_RESOLVED_SOURCE_VERSION", // AWS CodeBuild: https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
+    "CIRCLE_SHA1", // CircleCI: https://circleci.com/docs/2.0/env-vars/
+    "VERCEL_GIT_COMMIT_SHA", // Vercel docs: https://vercel.com/docs/concepts/projects/environment-variables#system-environment-variables
+  ];
+
+  const releaseFromEnvironmentVar = ENV_VARS.find((key) => Object.keys(process.env).includes(key));
+
+  if (releaseFromEnvironmentVar) {
+    return process.env[releaseFromEnvironmentVar] as string;
+  }
+
+  if (isGit(process.cwd())) {
+    return getBranchHead();
+  } else {
+    throw new Error("Could not return a release name");
+  }
+}

--- a/packages/unplugin/src/index.ts
+++ b/packages/unplugin/src/index.ts
@@ -1,5 +1,6 @@
 import { createUnplugin } from "unplugin";
 import MagicString from "magic-string";
+import { getReleaseName } from "./getReleaseName";
 import * as path from "path";
 
 function generateGlobalInjectorCode({ release }: { release: string }) {
@@ -14,11 +15,6 @@ function generateGlobalInjectorCode({ release }: { release: string }) {
             {};
 
     _global.SENTRY_RELEASE={id:"${release}"};`;
-}
-
-// TODO: Replace this function with actual logic
-function getReleaseName() {
-  return "default";
 }
 
 export interface Options {

--- a/packages/unplugin/test/getReleaseName.test.ts
+++ b/packages/unplugin/test/getReleaseName.test.ts
@@ -31,7 +31,7 @@ describe("environmental getReleaseName", () => {
     expect(getReleaseName()).toBe(sha);
   });
 
-  it("throws an error if git is not present", () => {
+  it("throws an error if no release information could be found", () => {
     (mockedFs.existsSync as jest.Mock).mockReturnValueOnce(false);
 
     expect(getReleaseName).toThrow("Could not return a release name");

--- a/packages/unplugin/test/getReleaseName.test.ts
+++ b/packages/unplugin/test/getReleaseName.test.ts
@@ -1,0 +1,98 @@
+import { getReleaseName } from "../src/getReleaseName";
+import * as fs from "fs";
+import * as child_process from "child_process";
+jest.mock("fs");
+jest.mock("child_process");
+
+const mockedFs = fs;
+const mockedChildProcess = child_process;
+
+describe("environmental getReleaseName", () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV };
+  });
+
+  afterEach(() => {
+    (mockedChildProcess.execSync as jest.Mock).mockRestore();
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  it("adheres to HEAD when git is present", () => {
+    (mockedFs.existsSync as jest.Mock).mockReturnValueOnce(true);
+    const sha = "c3f235fc86f1c4007e3a218ec82d666586e73cbf";
+    (mockedChildProcess.execSync as jest.Mock).mockReturnValue(sha);
+
+    expect(getReleaseName()).toBe(sha);
+  });
+
+  it("throws an error if git is not present", () => {
+    (mockedFs.existsSync as jest.Mock).mockReturnValueOnce(false);
+
+    expect(getReleaseName).toThrow("Could not return a release name");
+  });
+
+  it("adheres to user defined release name", () => {
+    const releaseName = "USER_DEFINED_this-is-my-custom-release";
+
+    expect(getReleaseName(releaseName)).toBe(releaseName);
+  });
+
+  it("adheres to process.env.SENTRY_RELEASE", () => {
+    const releaseName = "SENTRY_RELEASE_string";
+    process.env["SENTRY_RELEASE"] = releaseName;
+
+    expect(getReleaseName()).toBe(releaseName);
+  });
+
+  it("adheres to Heroku: process.env.SOURCE_VERSION", () => {
+    const releaseName = "SOURCE_VERSION_string";
+    process.env["SOURCE_VERSION"] = releaseName;
+
+    expect(getReleaseName()).toBe(releaseName);
+  });
+
+  it("adheres to Heroku: process.env.HEROKU_SLUG_COMMIT", () => {
+    const releaseName = "HEROKU_SLUG_COMMIT_string";
+    process.env["HEROKU_SLUG_COMMIT"] = releaseName;
+
+    expect(getReleaseName()).toBe(releaseName);
+  });
+
+  it("adheres to AWS: process.env.CODEBUILD_RESOLVED_SOURCE_VERSION", () => {
+    const releaseName = "CODEBUILD_RESOLVED_SOURCE_VERSION_string";
+    process.env["CODEBUILD_RESOLVED_SOURCE_VERSION"] = releaseName;
+
+    expect(getReleaseName()).toBe(releaseName);
+  });
+
+  it("adheres to Vercel: process.env.VERCEL_GIT_COMMIT_SHA", () => {
+    const releaseName = "VERCEL_GIT_COMMIT_SHA_string";
+    process.env["VERCEL_GIT_COMMIT_SHA"] = releaseName;
+
+    expect(getReleaseName()).toBe(releaseName);
+  });
+
+  it("allows SENTRY_RELEASE to take precedence over other env vars", () => {
+    const vercelReleaseName = "VERCEL_GIT_COMMIT_SHA_string";
+    const sentryReleaseName = "SENTRY_RELEASE_string";
+    process.env["VERCEL_GIT_COMMIT_SHA"] = vercelReleaseName;
+    process.env["SENTRY_RELEASE"] = sentryReleaseName;
+
+    expect(getReleaseName()).toBe(sentryReleaseName);
+  });
+
+  it("allows custom release name to take precedence over other env vars", () => {
+    const vercelReleaseName = "VERCEL_GIT_COMMIT_SHA_string";
+    const sentryReleaseName = "SENTRY_RELEASE_string";
+    process.env["VERCEL_GIT_COMMIT_SHA"] = vercelReleaseName;
+    process.env["SENTRY_RELEASE"] = sentryReleaseName;
+
+    expect(getReleaseName("cutom_release_name")).toBe("cutom_release_name");
+  });
+});


### PR DESCRIPTION
relates: #20  

This behaviour tries to replicate the behaviour of release option of sentry-webpack-plugin.

Release name can be specified via process.env.SENTRY_RELEASE. Otherwise, it will automatically detects values for Heroku, AWS CodeBuild, CircleCI and Vercel. Otherwise uses HEAD's commit SHA. (For HEAD option, requires access to git CLI and for the root directory to be a valid repository).

Logic taken from [sentry-cli here](https://github.com/getsentry/sentry-cli/blob/master/src/utils/releases.rs#L87-L143)