### PR TITLE
feat(sourcemaps): replace sourcemaps cli upload

### DIFF
--- a/packages/playground/vite.config.smallNodeApp.js
+++ b/packages/playground/vite.config.smallNodeApp.js
@@ -23,7 +23,7 @@ export default defineConfig({
       project: process.env.SENTRY_PROJECT,
       debug: true,
       debugLogging: true,
-      release: "hackweek-0.0.7",
+      release: "0.0.10",
       include: "out/vite-smallNodeApp",
       cleanArtifacts: true,
     }),

--- a/packages/unplugin/package.json
+++ b/packages/unplugin/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@sentry/cli": "1.74.5",
     "axios": "^0.27.2",
+    "form-data": "^4.0.0",
     "magic-string": "0.26.2",
     "unplugin": "0.9.4"
   },

--- a/packages/unplugin/rollup.config.js
+++ b/packages/unplugin/rollup.config.js
@@ -3,6 +3,7 @@ import resolve from "@rollup/plugin-node-resolve";
 import babel from "@rollup/plugin-babel";
 import packageJson from "./package.json";
 import json from "@rollup/plugin-json";
+import modulePackage from "module";
 
 const input = ["src/index.ts"];
 
@@ -10,8 +11,7 @@ const extensions = [".js", ".ts"];
 
 export default {
   input,
-  // external: [...Object.keys(packageJson.dependencies)],
-  external: ["path", "unplugin", "@sentry/cli"],
+  external: [...Object.keys(packageJson.dependencies), ...modulePackage.builtinModules],
   plugins: [
     resolve({ extensions, preferBuiltins: true }),
     commonjs(),

--- a/packages/unplugin/src/index.ts
+++ b/packages/unplugin/src/index.ts
@@ -12,6 +12,7 @@ const defaultOptions: Omit<Options, "include"> = {
   cleanArtifacts: false,
   finalize: true,
   url: "https://sentry.io",
+  ext: ["js", "map", "jsbundle", "bundle"],
 };
 
 /**

--- a/packages/unplugin/src/sentry/api.ts
+++ b/packages/unplugin/src/sentry/api.ts
@@ -1,5 +1,7 @@
 import axios from "axios";
 
+import FormData from "form-data";
+
 // We need to ignore the import because the package.json is not part of the TS project as configured in tsconfig.json
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
@@ -21,9 +23,9 @@ sentryApiAxiosInstance.interceptors.request.use((config) => {
 });
 
 export async function createRelease({
-  release,
-  project,
   org,
+  project,
+  release,
   authToken,
   sentryUrl,
 }: {
@@ -54,10 +56,10 @@ export async function createRelease({
 
 export async function deleteAllReleaseArtifacts({
   org,
-  release,
-  sentryUrl,
-  authToken,
   project,
+  release,
+  authToken,
+  sentryUrl,
 }: {
   org: string;
   release: string;
@@ -105,5 +107,41 @@ export async function updateRelease({
   } catch (e) {
     // TODO: Maybe do some more sopthisticated error handling here
     throw new Error("Something went wrong while creating a release");
+  }
+}
+
+export async function uploadReleaseFile({
+  org,
+  project,
+  release,
+  authToken,
+  sentryUrl,
+  filename,
+  fileContent,
+}: {
+  org: string;
+  release: string;
+  sentryUrl: string;
+  authToken: string;
+  project: string;
+  filename: string;
+  fileContent: string;
+}) {
+  const requestUrl = `${sentryUrl}${API_PATH}/projects/${org}/${project}/releases/${release}/files/`;
+
+  const form = new FormData();
+  form.append("name", filename);
+  form.append("file", Buffer.from(fileContent, "utf-8"), { filename });
+
+  try {
+    await sentryApiAxiosInstance.post(requestUrl, form, {
+      headers: {
+        Authorization: `Bearer ${authToken}`,
+        "Content-Type": "multipart/form-data",
+      },
+    });
+  } catch (e) {
+    // TODO: Maybe do some more sopthisticated error handling here
+    throw new Error(`Something went wrong while uploading file ${filename}`);
   }
 }

--- a/packages/unplugin/src/sentry/facade.ts
+++ b/packages/unplugin/src/sentry/facade.ts
@@ -130,9 +130,15 @@ async function uploadSourceMaps(
     return Promise.resolve("nothing to do here");
   }
 
+  // eslint-disable-next-line no-console
+  console.log("[Sentry-plugin] Uploading Sourcemaps.");
+
   //TODO: Remove this once we have internal options. this property must always be present
   const fileExtensions = ext || [];
   const files = getFiles(include, fileExtensions);
+
+  // eslint-disable-next-line no-console
+  console.log(`[Sentry-plugin] > Found ${files.length} files to upload.`);
 
   return Promise.all(
     files.map((file) =>
@@ -148,7 +154,7 @@ async function uploadSourceMaps(
     )
   ).then(() => {
     // eslint-disable-next-line no-console
-    console.log("[Sentry-plugin] Successfully created release.");
+    console.log("[Sentry-plugin] Successfully uploaded sourcemaps.");
     return "done";
   });
 }

--- a/packages/unplugin/src/sentry/facade.ts
+++ b/packages/unplugin/src/sentry/facade.ts
@@ -9,7 +9,8 @@
 import { makeSentryCli } from "./cli";
 import { Options } from "../types";
 import SentryCli from "@sentry/cli";
-import { createRelease, deleteAllReleaseArtifacts, updateRelease } from "./api";
+import { createRelease, deleteAllReleaseArtifacts, uploadReleaseFile, updateRelease } from "./api";
+import { getFiles } from "./sourcemaps";
 
 export type SentryFacade = {
   createNewRelease: () => Promise<string>;
@@ -76,12 +77,25 @@ async function uploadSourceMaps(
   release: string,
   options: Options
 ): Promise<string> {
-  /**
-   * One or more paths to ignore during upload. Overrides entries in ignoreFile file.
-   */
+  // This is what Sentry CLI does:
+  //  TODO: 0. Preprocess source maps
+  //           - (Out of scope for now)
+  //           - For rewriting source maps see https://github.com/getsentry/rust-sourcemap/blob/master/src/types.rs#L763
+  //  TODO: 1. Creates a new release to make sure it exists
+  //           - can we assume that the release will exist b/c we don't give unplugin users the
+  //           option to skip this step?
+  //  TODO: 2. download already uploaded files and get their checksums
+  //  TODO: 3. identify new or changed files (by comparing checksums)
+  //  TODO: 4. upload new and changed files
+  //           - CLI asks API for chunk options https://github.com/getsentry/sentry-cli/blob/7b8466885d9cfd51aee6fdc041eca9f645026303/src/utils/file_upload.rs#L106-L112
+  //           - WTF?
+  //           - don't upload more than 20k files
+  //           - upload files concurrently
+  //           - 2 options: chunked upload (multiple files per chunk) or single file upload
 
   const {
     include,
+    ext,
     // ignore,
     // ignoreFile,
     // rewrite,
@@ -91,16 +105,50 @@ async function uploadSourceMaps(
     // validate,
     // urlPrefix,
     // urlSuffix,
-    // ext,
+    org,
+    project,
+    authToken,
+    url,
   } = options;
 
-  //TODO: sort out mess between Sentry CLI options and WebPack plugin options (ideally,
-  //      we normalize everything before and don't diverge with options between our
-  //      own CLI implementation and the plugin.
-  //      I don't want to do too much for this right now b/c we'll eventually get rid of the CLI anyway
-  const uploadSourceMapsOptions = { include: typeof include === "string" ? [include] : include };
+  // TODO: pull these checks out of here and simplify them
+  if (authToken === undefined) {
+    // eslint-disable-next-line no-console
+    console.log('[Sentry-plugin] WARNING: Missing "authToken" option. Will not create release.');
+    return Promise.resolve("nothing to do here");
+  } else if (org === undefined) {
+    // eslint-disable-next-line no-console
+    console.log('[Sentry-plugin] WARNING: Missing "org" option. Will not create release.');
+    return Promise.resolve("nothing to do here");
+  } else if (url === undefined) {
+    // eslint-disable-next-line no-console
+    console.log('[Sentry-plugin] WARNING: Missing "url" option. Will not create release.');
+    return Promise.resolve("nothing to do here");
+  } else if (project === undefined) {
+    // eslint-disable-next-line no-console
+    console.log('[Sentry-plugin] WARNING: Missing "project" option. Will not create release.');
+    return Promise.resolve("nothing to do here");
+  }
 
-  return cli.releases.uploadSourceMaps(release, uploadSourceMapsOptions);
+  const files = getFiles(include, ext);
+
+  return Promise.all(
+    files.map((file) =>
+      uploadReleaseFile({
+        org,
+        project,
+        release,
+        authToken,
+        sentryUrl: url,
+        filename: file.name,
+        fileContent: file.content,
+      })
+    )
+  ).then(() => {
+    // eslint-disable-next-line no-console
+    console.log("[Sentry-plugin] Successfully created release.");
+    return "done";
+  });
 }
 
 async function finalizeRelease(

--- a/packages/unplugin/src/sentry/facade.ts
+++ b/packages/unplugin/src/sentry/facade.ts
@@ -130,7 +130,9 @@ async function uploadSourceMaps(
     return Promise.resolve("nothing to do here");
   }
 
-  const files = getFiles(include, ext);
+  //TODO: Remove this once we have internal options. this property must always be present
+  const fileExtensions = ext || [];
+  const files = getFiles(include, fileExtensions);
 
   return Promise.all(
     files.map((file) =>

--- a/packages/unplugin/src/sentry/sourcemaps.ts
+++ b/packages/unplugin/src/sentry/sourcemaps.ts
@@ -20,20 +20,19 @@ function getAllIncludedFileNames(
   allowedExtensions: string[],
   accFiles: string[]
 ): string[] {
-  let allFiles = accFiles;
   const files = fs.readdirSync(dirPath);
 
   files
     .map((file) => path.join(dirPath, "/", file))
     .forEach((file) => {
       if (fs.statSync(file).isDirectory()) {
-        allFiles = getAllIncludedFileNames(file, allowedExtensions, allFiles);
+        accFiles.concat(getAllIncludedFileNames(file, allowedExtensions, accFiles));
       } else {
         if (allowedExtensions.some((e) => file.endsWith(e))) {
-          allFiles.push(file);
+          accFiles.push(file);
         }
       }
     });
 
-  return allFiles;
+  return accFiles;
 }

--- a/packages/unplugin/src/sentry/sourcemaps.ts
+++ b/packages/unplugin/src/sentry/sourcemaps.ts
@@ -1,0 +1,39 @@
+import path from "path";
+import fs from "fs";
+
+export type FileRecord = {
+  name: string;
+  content: string;
+};
+
+export function getFiles(path: string, allowedExtensions: string[]): FileRecord[] {
+  const includedFiles = getAllIncludedFileNames(path, allowedExtensions, []);
+
+  return includedFiles.map((filename) => {
+    const content = fs.readFileSync(filename, { encoding: "utf-8" });
+    return { name: "~" + filename.replace(new RegExp(`^${path}`), ""), content };
+  });
+}
+
+function getAllIncludedFileNames(
+  dirPath: string,
+  allowedExtensions: string[],
+  accFiles: string[]
+): string[] {
+  let allFiles = accFiles;
+  const files = fs.readdirSync(dirPath);
+
+  files
+    .map((file) => path.join(dirPath, "/", file))
+    .forEach((file) => {
+      if (fs.statSync(file).isDirectory()) {
+        allFiles = getAllIncludedFileNames(file, allowedExtensions, allFiles);
+      } else {
+        if (allowedExtensions.some((e) => file.endsWith(e))) {
+          allFiles.push(file);
+        }
+      }
+    });
+
+  return allFiles;
+}

--- a/packages/unplugin/src/types.ts
+++ b/packages/unplugin/src/types.ts
@@ -20,7 +20,7 @@ export type Options = {
   include: string; // | Array<string | IncludeEntry>;
   // ignoreFile: string
   // ignore: string | string[]
-  ext: string[];
+  ext?: string[];
   // urlPrefix: string,
   // urlSuffix: string,
   // validate: boolean

--- a/packages/unplugin/src/types.ts
+++ b/packages/unplugin/src/types.ts
@@ -20,7 +20,7 @@ export type Options = {
   include: string; // | Array<string | IncludeEntry>;
   // ignoreFile: string
   // ignore: string | string[]
-  // ext: string[]
+  ext: string[];
   // urlPrefix: string,
   // urlSuffix: string,
   // validate: boolean


### PR DESCRIPTION
This PR adds a very(!) basic sourcemap upload functionality:

- per-file based sourcemaps upload (not chunked)
- no sourcemaps preprocessing