### PR TITLE
feat: Add Sentry

### DIFF
--- a/packages/unplugin/package.json
+++ b/packages/unplugin/package.json
@@ -20,6 +20,8 @@
     "lint": "eslint ./src ./test"
   },
   "dependencies": {
+    "@sentry/node": "^7.11.1",
+    "@sentry/tracing": "^7.11.1",
     "axios": "^0.27.2",
     "form-data": "^4.0.0",
     "magic-string": "0.26.2",

--- a/packages/unplugin/src/index.ts
+++ b/packages/unplugin/src/index.ts
@@ -97,7 +97,12 @@ const unplugin = createUnplugin<Options>((originalOptions, unpluginMetaContext) 
     console.log("[Sentry-Plugin]", "To disable telemetry, set `options.telemetry` to `false`.");
   }
 
-  sentryHub?.setTags({ organization: options.org, project: options.project });
+  sentryHub?.setTags({
+    organization: options.org,
+    project: options.project,
+    bundler: unpluginMetaContext.framework,
+  });
+
   sentryHub?.setUser({ id: options.org });
 
   function debugLog(...args: unknown[]) {

--- a/packages/unplugin/src/index.ts
+++ b/packages/unplugin/src/index.ts
@@ -8,8 +8,6 @@ import "@sentry/tracing";
 
 Sentry.init({
   dsn: "https://1298ac2f87bc4aae99d9a9a94ce65b42@o447951.ingest.sentry.io/6681372",
-  debug: true,
-  sampleRate: 1.0,
   tracesSampleRate: 1.0,
   integrations: [new Sentry.Integrations.Http({ tracing: true })],
 });

--- a/packages/unplugin/src/index.ts
+++ b/packages/unplugin/src/index.ts
@@ -82,7 +82,7 @@ const unplugin = createUnplugin<Options>((originalOptions, unpluginMetaContext) 
   //TODO: We can get rid of this variable once we have internal plugin options
   const telemetryEnabled = options.telemetry === true;
 
-  const { client: sentryClient, hub: sentryHub } = makeSentryClient(
+  const { hub: sentryHub } = makeSentryClient(
     "https://4c2bae7d9fbc413e8f7385f55c515d51@o1.ingest.sentry.io/6690737",
     telemetryEnabled,
     options.org

--- a/packages/unplugin/src/index.ts
+++ b/packages/unplugin/src/index.ts
@@ -90,6 +90,13 @@ const unplugin = createUnplugin<Options>((originalOptions, unpluginMetaContext) 
     options.org || ""
   );
 
+  if (sentryClient && sentryHub) {
+    // eslint-disable-next-line no-console
+    console.log("[Sentry-plugin]", "Sending error and performance telemetry data to Sentry.");
+    // eslint-disable-next-line no-console
+    console.log("[Sentry-Plugin]", "To disable telemetry, set `options.telemetry` to `false`.");
+  }
+
   sentryHub?.setTags({ organization: options.org, project: options.project });
   sentryHub?.setUser({ id: options.org });
 

--- a/packages/unplugin/src/sentry/api.ts
+++ b/packages/unplugin/src/sentry/api.ts
@@ -42,6 +42,7 @@ export async function createRelease({
     });
   } catch (e) {
     Sentry.captureException(e);
+    throw e;
   }
 }
 
@@ -68,6 +69,7 @@ export async function deleteAllReleaseArtifacts({
     });
   } catch (e) {
     Sentry.captureException(e);
+    throw e;
   }
 }
 
@@ -96,6 +98,7 @@ export async function updateRelease({
     });
   } catch (e) {
     Sentry.captureException(e);
+    throw e;
   }
 }
 
@@ -131,5 +134,6 @@ export async function uploadReleaseFile({
     });
   } catch (e) {
     Sentry.captureException(e);
+    throw e;
   }
 }

--- a/packages/unplugin/src/sentry/api.ts
+++ b/packages/unplugin/src/sentry/api.ts
@@ -12,16 +12,7 @@ const API_PATH = "/api/0";
 
 // eslint-disable-next-line @typescript-eslint/restrict-template-expressions, @typescript-eslint/no-unsafe-member-access
 const USER_AGENT = `sentry-unplugin/${unpluginVersion}`;
-const sentryApiAxiosInstance = axios.create();
-sentryApiAxiosInstance.interceptors.request.use((config) => {
-  return {
-    ...config,
-    headers: {
-      ...config.headers,
-      "User-Agent": USER_AGENT,
-    },
-  };
-});
+const sentryApiAxiosInstance = axios.create({ headers: { "User-Agent": USER_AGENT } });
 
 export async function createRelease({
   org,

--- a/packages/unplugin/src/sentry/api.ts
+++ b/packages/unplugin/src/sentry/api.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 
 import FormData from "form-data";
+import * as Sentry from "@sentry/node";
 
 // We need to ignore the import because the package.json is not part of the TS project as configured in tsconfig.json
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -49,8 +50,7 @@ export async function createRelease({
       headers: { Authorization: `Bearer ${authToken}` },
     });
   } catch (e) {
-    // TODO: Maybe do some more sopthisticated error handling here
-    throw new Error("Something went wrong while creating a release");
+    Sentry.captureException(e);
   }
 }
 
@@ -76,8 +76,7 @@ export async function deleteAllReleaseArtifacts({
       },
     });
   } catch (e) {
-    // TODO: Maybe do some more sopthisticated error handling here
-    throw new Error("Something went wrong while cleaning previous release artifacts");
+    Sentry.captureException(e);
   }
 }
 
@@ -105,8 +104,7 @@ export async function updateRelease({
       headers: { Authorization: `Bearer ${authToken}` },
     });
   } catch (e) {
-    // TODO: Maybe do some more sopthisticated error handling here
-    throw new Error("Something went wrong while creating a release");
+    Sentry.captureException(e);
   }
 }
 
@@ -141,7 +139,6 @@ export async function uploadReleaseFile({
       },
     });
   } catch (e) {
-    // TODO: Maybe do some more sopthisticated error handling here
-    throw new Error(`Something went wrong while uploading file ${filename}`);
+    Sentry.captureException(e);
   }
 }

--- a/packages/unplugin/src/sentry/api.ts
+++ b/packages/unplugin/src/sentry/api.ts
@@ -1,7 +1,6 @@
 import axios from "axios";
 
 import FormData from "form-data";
-import * as Sentry from "@sentry/node";
 
 // We need to ignore the import because the package.json is not part of the TS project as configured in tsconfig.json
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/unplugin/src/sentry/api.ts
+++ b/packages/unplugin/src/sentry/api.ts
@@ -7,6 +7,8 @@ import * as Sentry from "@sentry/node";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { version as unpluginVersion } from "../../package.json";
+import { captureMinimalError } from "./telemetry";
+import { Hub } from "@sentry/node";
 
 const API_PATH = "/api/0";
 
@@ -20,12 +22,14 @@ export async function createRelease({
   release,
   authToken,
   sentryUrl,
+  sentryHub,
 }: {
   release: string;
   project: string;
   org: string;
   authToken: string;
   sentryUrl: string;
+  sentryHub: Hub;
 }): Promise<void> {
   const requestUrl = `${sentryUrl}${API_PATH}/organizations/${org}/releases/`;
 
@@ -41,7 +45,7 @@ export async function createRelease({
       headers: { Authorization: `Bearer ${authToken}` },
     });
   } catch (e) {
-    Sentry.captureException(e);
+    captureMinimalError(e, sentryHub);
     throw e;
   }
 }
@@ -52,12 +56,14 @@ export async function deleteAllReleaseArtifacts({
   release,
   authToken,
   sentryUrl,
+  sentryHub,
 }: {
   org: string;
   release: string;
   sentryUrl: string;
   authToken: string;
   project: string;
+  sentryHub: Hub;
 }): Promise<void> {
   const requestUrl = `${sentryUrl}${API_PATH}/projects/${org}/${project}/files/source-maps/?name=${release}`;
 
@@ -68,7 +74,7 @@ export async function deleteAllReleaseArtifacts({
       },
     });
   } catch (e) {
-    Sentry.captureException(e);
+    captureMinimalError(e, sentryHub);
     throw e;
   }
 }
@@ -79,12 +85,14 @@ export async function updateRelease({
   authToken,
   sentryUrl,
   project,
+  sentryHub,
 }: {
   release: string;
   org: string;
   authToken: string;
   sentryUrl: string;
   project: string;
+  sentryHub: Hub;
 }): Promise<void> {
   const requestUrl = `${sentryUrl}${API_PATH}/projects/${org}/${project}/releases/${release}/`;
 
@@ -97,7 +105,7 @@ export async function updateRelease({
       headers: { Authorization: `Bearer ${authToken}` },
     });
   } catch (e) {
-    Sentry.captureException(e);
+    captureMinimalError(e, sentryHub);
     throw e;
   }
 }
@@ -110,6 +118,7 @@ export async function uploadReleaseFile({
   sentryUrl,
   filename,
   fileContent,
+  sentryHub,
 }: {
   org: string;
   release: string;
@@ -118,6 +127,7 @@ export async function uploadReleaseFile({
   project: string;
   filename: string;
   fileContent: string;
+  sentryHub: Hub;
 }) {
   const requestUrl = `${sentryUrl}${API_PATH}/projects/${org}/${project}/releases/${release}/files/`;
 
@@ -133,7 +143,7 @@ export async function uploadReleaseFile({
       },
     });
   } catch (e) {
-    Sentry.captureException(e);
+    captureMinimalError(e, sentryHub);
     throw e;
   }
 }

--- a/packages/unplugin/src/sentry/facade.ts
+++ b/packages/unplugin/src/sentry/facade.ts
@@ -26,8 +26,8 @@ export type SentryFacade = {
  * Factory function that provides all necessary Sentry functionality for creating
  * a release on Sentry. This includes uploading source maps and finalizing the release
  */
-export function makeSentryFacade(release: string, options: Options, sentryHub?: Hub): SentryFacade {
-  const span = sentryHub?.getScope()?.getSpan();
+export function makeSentryFacade(release: string, options: Options, sentryHub: Hub): SentryFacade {
+  const span = sentryHub.getScope()?.getSpan();
   return {
     createNewRelease: () => createNewRelease(release, options, sentryHub, span),
     cleanArtifacts: () => cleanArtifacts(release, options, sentryHub, span),
@@ -41,7 +41,7 @@ export function makeSentryFacade(release: string, options: Options, sentryHub?: 
 async function createNewRelease(
   release: string,
   options: Options,
-  sentryHub?: Hub,
+  sentryHub: Hub,
   parentSpan?: Span
 ): Promise<string> {
   const span = addSpanToTransaction(sentryHub, parentSpan, "create-new-release");
@@ -71,6 +71,7 @@ async function createNewRelease(
     org: options.org,
     project: options.project,
     sentryUrl: options.url,
+    sentryHub,
   });
 
   // eslint-disable-next-line no-console
@@ -83,7 +84,7 @@ async function createNewRelease(
 async function uploadSourceMaps(
   release: string,
   options: Options,
-  sentryHub?: Hub,
+  sentryHub: Hub,
   parentSpan?: Span
 ): Promise<string> {
   const span = addSpanToTransaction(sentryHub, parentSpan, "upload-sourceMaps");
@@ -159,6 +160,7 @@ async function uploadSourceMaps(
         sentryUrl: url,
         filename: file.name,
         fileContent: file.content,
+        sentryHub,
       })
     )
   ).then(() => {
@@ -172,7 +174,7 @@ async function uploadSourceMaps(
 async function finalizeRelease(
   release: string,
   options: Options,
-  sentryHub?: Hub,
+  sentryHub: Hub,
   parentSpan?: Span
 ): Promise<string> {
   const span = addSpanToTransaction(sentryHub, parentSpan, "finalize-release");
@@ -193,6 +195,7 @@ async function finalizeRelease(
       release,
       sentryUrl: url,
       project,
+      sentryHub,
     });
     // eslint-disable-next-line no-console
     console.log("[Sentry-plugin] Successfully finalized release.");
@@ -205,7 +208,7 @@ async function finalizeRelease(
 async function cleanArtifacts(
   release: string,
   options: Options,
-  sentryHub?: Hub,
+  sentryHub: Hub,
   parentSpan?: Span
 ): Promise<string> {
   const span = addSpanToTransaction(sentryHub, parentSpan, "clean-artifacts");
@@ -244,6 +247,7 @@ async function cleanArtifacts(
       release,
       sentryUrl: options.url,
       project: options.project,
+      sentryHub,
     });
 
     // eslint-disable-next-line no-console
@@ -258,7 +262,7 @@ async function cleanArtifacts(
 
 async function setCommits(
   /* version: string, */
-  sentryHub?: Hub,
+  sentryHub: Hub,
   parentSpan?: Span
 ): Promise<string> {
   const span = addSpanToTransaction(sentryHub, parentSpan, "set-commits");
@@ -269,7 +273,7 @@ async function setCommits(
 
 async function addDeploy(
   /* version: string, */
-  sentryHub?: Hub,
+  sentryHub: Hub,
   parentSpan?: Span
 ): Promise<string> {
   const span = addSpanToTransaction(sentryHub, parentSpan, "add-deploy");

--- a/packages/unplugin/src/sentry/telemetry.ts
+++ b/packages/unplugin/src/sentry/telemetry.ts
@@ -25,7 +25,7 @@ export function makeSentryClient(
     tracePropagationTargets: ["sentry.io/api"],
     stackParser: defaultStackParser,
     transport: makeNodeTransport,
-    release: `${org}@${unpluginVersion}`,
+    release: `${org ? `${org}@` : ""}${unpluginVersion}`,
     debug: true,
   });
   const hub = new Hub(client);

--- a/packages/unplugin/src/sentry/telemetry.ts
+++ b/packages/unplugin/src/sentry/telemetry.ts
@@ -1,0 +1,63 @@
+import {
+  defaultStackParser,
+  Hub,
+  Integrations,
+  makeMain,
+  makeNodeTransport,
+  NodeClient,
+  NodeOptions,
+} from "@sentry/node";
+import { Span } from "@sentry/tracing";
+import { version as unpluginVersion } from "../../package.json";
+
+export function makeSentryClient(
+  telemetryEnabled: boolean,
+  options: NodeOptions,
+  org: string
+): { client?: NodeClient; hub?: Hub } {
+  if (!telemetryEnabled) {
+    return { client: undefined, hub: undefined };
+  }
+  const client = new NodeClient({
+    ...options,
+    tracesSampleRate: 1.0,
+    integrations: [new Integrations.Http({ tracing: true })],
+    tracePropagationTargets: ["sentry.io/api"],
+    stackParser: defaultStackParser,
+    transport: makeNodeTransport,
+    release: `${org}@${unpluginVersion}`,
+    debug: true,
+  });
+  const hub = new Hub(client);
+
+  //TODO: This call is be problematic because as soon as we set our hub as the current hub
+  //      we might interfere with other plugins that use Sentry. However, for now, we'll
+  //      leave it in because without it, we can't get distributed traces (which are pretty nice)
+  //      Let's keep it until someone complains about interference.
+  //      The ideal solution would be a code change in the JS SDK but it's not a straight-forward fix.
+  makeMain(hub);
+
+  return { client, hub };
+}
+
+/**
+ * Adds a span to the passed parentSpan or to the current transaction that's on the passed hub's scope.
+ */
+export function addSpanToTransaction(
+  sentryHub?: Hub,
+  parentSpan?: Span,
+  op?: string,
+  description?: string
+): Span | undefined {
+  if (!sentryHub) {
+    // If we don't have a hub here, this means that users have disabled telemetry
+    // So we don't do anything
+    return undefined;
+  }
+
+  const actualSpan = parentSpan || sentryHub.getScope()?.getTransaction();
+  const span = actualSpan?.startChild({ op, description });
+  sentryHub.configureScope((scope) => scope.setSpan(span));
+
+  return span;
+}

--- a/packages/unplugin/src/types.ts
+++ b/packages/unplugin/src/types.ts
@@ -64,6 +64,18 @@ export type Options = {
   //   name?: string,
   //   url?: string,
   // }
+
+  /**
+   * If set to true, internal plugin errors and performance data will be sent to Sentry.
+   *
+   * At Sentry we like to use Sentry ourselves to deliver faster and more stable products.
+   * We're very careful of what we're sending. We won't collect anything other than error
+   * and high-level performance data. We will never collect your code or any details of the
+   * projects in which you're using this plugin.
+   *
+   * Defaults to true
+   */
+  telemetry?: boolean;
 };
 
 /*

--- a/yarn.lock
+++ b/yarn.lock
@@ -1635,6 +1635,16 @@
     lru_map "^0.3.3"
     tslib "^1.9.3"
 
+"@sentry/tracing@^7.11.1":
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.11.1.tgz#50cbe82dd5b9a1307b31761cdd4b0d71132cf5c7"
+  integrity sha512-ilgnHfpdYUWKG/5yAXIfIbPVsCfrC4ONFBR/wN25/hdAyVfXMa3AJx7NCCXxZBOPDWH3hMW8rl4La5yuDbXofg==
+  dependencies:
+    "@sentry/hub" "7.11.1"
+    "@sentry/types" "7.11.1"
+    "@sentry/utils" "7.11.1"
+    tslib "^1.9.3"
+
 "@sentry/types@7.11.1":
   version "7.11.1"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.11.1.tgz#06e2827f6ba37159c33644208a0453b86d25e232"


### PR DESCRIPTION
This PR adds Sentry integration to sentry-unplugin.

This will allow us to proactively monitor and get alerted about our customers errors.

### Error page:
<img width="1505" alt="Screenshot 2022-08-25 at 02 31 49" src="https://user-images.githubusercontent.com/29886766/186547646-4d38548f-bce8-4e8e-b5c0-6a0fc175515f.png">


### Performance:
<img width="1481" alt="Screenshot 2022-08-25 at 02 20 54" src="https://user-images.githubusercontent.com/29886766/186547012-2a6b3877-fa58-478d-acc1-ac9c9a4c6d74.png">


_Side note so I don't forget:
I would have expected to get distributed tracing when making requests to sentry API as we are sending `sentry-trace`. Let's discuss why this could happen. Different org maybe?_
