### PR TITLE
ref(unplugin): Clean up logger

### DIFF
--- a/packages/unplugin/src/index.ts
+++ b/packages/unplugin/src/index.ts
@@ -13,7 +13,7 @@ import {
 import "@sentry/tracing";
 import { addSpanToTransaction, captureMinimalError, makeSentryClient } from "./sentry/telemetry";
 import { Span, Transaction } from "@sentry/types";
-import sentryLogger from "./sentry/logger";
+import { createLogger } from "./sentry/logger";
 
 const defaultOptions: Omit<Options, "include"> = {
   //TODO: add default options here as we port over options from the webpack plugin
@@ -95,7 +95,11 @@ const unplugin = createUnplugin<Options>((originalOptions, unpluginMetaContext) 
     options.org
   );
 
-  const logger = sentryLogger({ options, hub: sentryHub });
+  const logger = createLogger({
+    hub: sentryHub,
+    prefix: `[sentry-${unpluginMetaContext.framework}-plugin]`,
+    silent: options.silent,
+  });
 
   if (telemetryEnabled) {
     logger.info("Sending error and performance telemetry data to Sentry.");

--- a/packages/unplugin/src/sentry/logger.ts
+++ b/packages/unplugin/src/sentry/logger.ts
@@ -1,15 +1,14 @@
-import { Options } from "../types";
-import { SeverityLevel } from "@sentry/node";
-import { Hub } from "@sentry/node";
-interface LoggerI {
-  options: Pick<Options, "silent" | "org">;
-  hub: Hub;
-}
-export default function logger(props: LoggerI) {
-  const prefix = "[Sentry-unplugin]";
+import { SeverityLevel, Hub } from "@sentry/node";
 
+interface LoggerOptions {
+  silent?: boolean;
+  hub: Hub;
+  prefix: string;
+}
+
+export function createLogger(options: LoggerOptions) {
   function addBreadcrumb(level: SeverityLevel, message: string) {
-    props.hub.addBreadcrumb({
+    options.hub.addBreadcrumb({
       category: "logger",
       level,
       message,
@@ -17,27 +16,26 @@ export default function logger(props: LoggerI) {
   }
 
   return {
-    prefix,
     info(message: string) {
-      if (!props.options.silent) {
+      if (!options?.silent) {
         // eslint-disable-next-line no-console
-        console.info(prefix, message);
+        console.log(`${options.prefix} ${message}`);
       }
 
       addBreadcrumb("info", message);
     },
     warn(message: string) {
-      if (!props.options.silent) {
+      if (!options?.silent) {
         // eslint-disable-next-line no-console
-        console.warn(prefix, message);
+        console.log(`${options.prefix} Warning: ${message}`);
       }
 
       addBreadcrumb("warning", message);
     },
     error(message: string) {
-      if (!props.options.silent) {
+      if (!options?.silent) {
         // eslint-disable-next-line no-console
-        console.error(prefix, message);
+        console.log(`${options.prefix} Error: ${message}`);
       }
 
       addBreadcrumb("error", message);

--- a/packages/unplugin/src/sentry/logger.ts
+++ b/packages/unplugin/src/sentry/logger.ts
@@ -27,7 +27,7 @@ export function createLogger(options: LoggerOptions) {
     warn(message: string) {
       if (!options?.silent) {
         // eslint-disable-next-line no-console
-        console.log(`${options.prefix} Warning: ${message}`);
+        console.log(`${options.prefix} Warning! ${message}`);
       }
 
       addBreadcrumb("warning", message);

--- a/packages/unplugin/src/types.ts
+++ b/packages/unplugin/src/types.ts
@@ -2,7 +2,7 @@
 
 import { Hub } from "@sentry/hub";
 import { Span } from "@sentry/tracing";
-import sentryLogger from "./sentry/logger";
+import { createLogger } from "./sentry/logger";
 
 //TODO: compare types w/ webpack plugin (and sentry-cli?)
 export type Options = {
@@ -108,5 +108,5 @@ type IncludeEntry = {
 export type BuildContext = {
   hub: Hub;
   parentSpan?: Span;
-  logger: ReturnType<typeof sentryLogger>;
+  logger: ReturnType<typeof createLogger>;
 };

--- a/packages/unplugin/test/logger.test.ts
+++ b/packages/unplugin/test/logger.test.ts
@@ -1,19 +1,8 @@
-// import {makeSentryClient} from "../src/sentry/telemetry"
 import { Hub } from "@sentry/node";
-import sentryLogger from "../src/sentry/logger";
+import { createLogger } from "../src/sentry/logger";
 
 describe("Logger", () => {
-  const info = jest.spyOn(console, "info").mockImplementation(() => {
-    return;
-  });
-  const warn = jest.spyOn(console, "warn").mockImplementation(() => {
-    return;
-  });
-  const error = jest.spyOn(console, "error").mockImplementation(() => {
-    return;
-  });
-
-  const spy = { info, warn, error };
+  const consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => undefined);
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
@@ -26,37 +15,63 @@ describe("Logger", () => {
   const mockedAddBreadcrumb = jest.spyOn(hub, "addBreadcrumb");
 
   afterEach(() => {
-    info.mockReset();
-    warn.mockReset();
-    error.mockReset();
+    consoleLogSpy.mockReset();
     mockedAddBreadcrumb.mockReset();
   });
 
-  const CASES = ["info", "warn", "error"];
+  it(".info() should log correctly", () => {
+    const prefix = "[some-prefix]";
+    const logger = createLogger({ hub, prefix });
+    logger.info("Hey!");
 
-  it.each(CASES)("logs (%s)", (a: string) => {
-    const logger = sentryLogger({ options: { silent: false }, hub });
-    // "info" -> make typescript happy
-    logger[a as "info"]("Hey!");
-
-    expect(spy[a as "info"]).toHaveBeenCalledWith(logger.prefix, "Hey!");
+    expect(consoleLogSpy).toHaveBeenCalledWith("[some-prefix] Hey!");
     expect(mockedAddBreadcrumb).toHaveBeenCalledWith({
       category: "logger",
-      level: a === "warn" ? "warning" : a,
+      level: "info",
       message: "Hey!",
     });
   });
 
-  it.each(CASES)("does not log (%s)", (a: string) => {
-    const logger = sentryLogger({ options: { silent: true }, hub });
-    // "info" -> make typescript happy
-    logger[a as "info"]("Hey!");
+  it(".warn() should log correctly", () => {
+    const prefix = "[some-prefix]";
+    const logger = createLogger({ hub, prefix });
+    logger.warn("Hey!");
 
-    expect(spy[a as "info"]).not.toHaveBeenCalledWith(logger.prefix, "Hey!");
+    expect(consoleLogSpy).toHaveBeenCalledWith("[some-prefix] Warning: Hey!");
     expect(mockedAddBreadcrumb).toHaveBeenCalledWith({
       category: "logger",
-      level: a === "warn" ? "warning" : a,
+      level: "warning",
       message: "Hey!",
+    });
+  });
+
+  it(".error() should log correctly", () => {
+    const prefix = "[some-prefix]";
+    const logger = createLogger({ hub, prefix });
+    logger.error("Hey!");
+
+    expect(consoleLogSpy).toHaveBeenCalledWith("[some-prefix] Error: Hey!");
+    expect(mockedAddBreadcrumb).toHaveBeenCalledWith({
+      category: "logger",
+      level: "error",
+      message: "Hey!",
+    });
+  });
+
+  describe("doesn't log when `silent` option is `true`", () => {
+    it.each(["info", "warn", "error"] as const)(".%s()", (loggerMethod) => {
+      const prefix = "[some-prefix]";
+      const logger = createLogger({ silent: true, hub, prefix });
+
+      logger[loggerMethod]("Hey!");
+
+      expect(consoleLogSpy).not.toHaveBeenCalled();
+
+      expect(mockedAddBreadcrumb).toHaveBeenCalledWith({
+        category: "logger",
+        level: expect.stringMatching(/.*/) as string,
+        message: "Hey!",
+      });
     });
   });
 });

--- a/packages/unplugin/test/logger.test.ts
+++ b/packages/unplugin/test/logger.test.ts
@@ -37,7 +37,7 @@ describe("Logger", () => {
     const logger = createLogger({ hub, prefix });
     logger.warn("Hey!");
 
-    expect(consoleLogSpy).toHaveBeenCalledWith("[some-prefix] Warning: Hey!");
+    expect(consoleLogSpy).toHaveBeenCalledWith("[some-prefix] Warning! Hey!");
     expect(mockedAddBreadcrumb).toHaveBeenCalledWith({
       category: "logger",
       level: "warning",


### PR DESCRIPTION
Just some opinionated cleaning up of the logger (reducing API surface, minor naming changes, test cleanup, and so forth).

Some changes are objective though:
- We call `console.log` instead of `console.warn` and `console.error`. Reason is that `.warn` is just an alias for `.error` and `.error` writes to stderr instead of stdout and we don't want that.
- Don't expose `prefix` on logger - it's unnecessary.
- Instead of prefixing with `[Sentry-unplugin]` we're now prefixing with `[sentry-{insert bundler here}-plugin]`.